### PR TITLE
Import Rcpp

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,6 +9,7 @@ URL: https://docs.ropensci.org/xslt (website)
     https://github.com/ropensci/xslt (devel)
 BugReports: https://github.com/ropensci/xslt/issues
 Depends: xml2 (>= 1.1.0)
+Imports: Rcpp
 LinkingTo: Rcpp, xml2
 SystemRequirements: libxslt: libxslt1-dev (deb), libxslt-devel (rpm)
 License: GPL (>= 2)

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,5 +3,6 @@
 S3method(xml_xslt,xml_document)
 export(xml_xslt)
 export(xslt_version)
+importFrom(Rcpp,sourceCpp)
 importFrom(xml2,read_xml)
 useDynLib(xslt)

--- a/R/xml_xslt.R
+++ b/R/xml_xslt.R
@@ -14,6 +14,7 @@
 #' @name xslt
 #' @useDynLib xslt
 #' @importFrom xml2 read_xml
+#' @importFrom Rcpp sourceCpp
 #' @param doc xml document as returned by [xml2::read_xml]
 #' @param stylesheet another xml document containing the XSL stylesheet
 #' @param params named list or vector with additional XSLT parameters


### PR DESCRIPTION
xml2 1.3.0 no longer uses Rcpp, so we need to import Rcpp in xslt to
ensure it is loaded when the functions are called. Otherwise you get the
following error from the examples

    Error in doc_xslt_apply(doc$doc, stylesheet$doc, paramstr) :
      function 'enterRNGScope' not provided by package 'Rcpp'
    Calls: xml_xslt -> xml_xslt.xml_document -> doc_xslt_apply